### PR TITLE
ダミー用ログインを作成しました。

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { GetIntraname } from './decorator/get-intraname.decorator';
 import { FtOauthGuard } from './guards/ft-oauth.guard';
@@ -19,6 +27,16 @@ export class AuthController {
     console.log(intraname, ' login !');
 
     return await this.authService.login(intraname);
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post('dummyLogin')
+  async dummyLogin(
+    @Body() body: { intraname: string }
+  ): Promise<{ accessToken: string }> {
+    const { intraname } = body;
+
+    return await this.authService.dummyLogin(intraname);
   }
 
   // @HttpCode(HttpStatus.OK)

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -17,6 +17,23 @@ export class AuthService {
     let user = await this.prisma.user.findUnique({ where: { name } });
     if (user === null) {
       user = await this.prisma.user.create({ data: { name } });
+    }
+
+    const payload: { id: string; name: string } = user;
+    const accessToken = await this.jwt.signAsync(payload, {
+      expiresIn: '1d',
+      secret: this.config.get('JWT_SECRET') as string,
+    });
+
+    return { accessToken };
+  }
+
+  async dummyLogin(intraname: string): Promise<{ accessToken: string }> {
+    const name: string = intraname;
+
+    const user = await this.prisma.user.findUnique({ where: { name } });
+    if (user === null) {
+      throw new UnauthorizedException('Name incorrect');
     }
 
     const payload: { id: string; name: string } = user;


### PR DESCRIPTION
ダミー用のログインとして、'dummyLogin'エンドポイントを作成しました。
seedで作成したダミーデータに対して使う予定です。
データベースに無い場合はUnauthorizedExceptionを投げます。
該当があれば、JWTトークン作成して、返します。