### PR TITLE
file module を追加

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
+import { FileModule } from './file/file.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { UsersModule } from './users/users.module';
 
@@ -10,6 +11,7 @@ import { UsersModule } from './users/users.module';
     AuthModule,
     UsersModule,
     PrismaModule,
+    FileModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/file/file.module.ts
+++ b/backend/src/file/file.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { FileService } from './file.service';
+
+@Module({
+  providers: [FileService],
+  exports: [FileService],
+})
+export class FileModule {}

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -1,0 +1,55 @@
+import { createReadStream, existsSync, mkdirSync, unlinkSync } from 'fs';
+import { extname } from 'path';
+import {
+  FileTypeValidator,
+  Injectable,
+  MaxFileSizeValidator,
+  ParseFilePipe,
+  StreamableFile,
+} from '@nestjs/common';
+import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
+import { User } from '@prisma/client';
+import { Request } from 'express';
+import { diskStorage } from 'multer';
+
+@Injectable()
+export class FileService {
+  static multerOptions = (): MulterOptions => ({
+    storage: diskStorage({
+      destination: (req: Request & { user?: { user?: User } }, file, cb) => {
+        const dir = `./upload/${req.user?.user?.id ?? ''}/`;
+        if (!existsSync(dir)) {
+          mkdirSync(dir, { recursive: true });
+        }
+        cb(null, dir);
+      },
+      filename: (req: Request & { user?: { user?: User } }, file, cb) => {
+        cb(null, `${req.user?.user?.name ?? ''}${extname(file.originalname)}`);
+      },
+    }),
+  });
+
+  static parseFilePipe = (): ParseFilePipe =>
+    new ParseFilePipe({
+      validators: [
+        new MaxFileSizeValidator({ maxSize: 10000000 }),
+        new FileTypeValidator({ fileType: /jpeg|png|jpg/ }),
+      ],
+    });
+
+  streamFile(path: string): StreamableFile {
+    const file = createReadStream(path);
+
+    return new StreamableFile(file);
+  }
+
+  deleteOldFile(newFilename: string, user: User): void {
+    const oldExtname = extname(user.avatarUrl);
+    if (oldExtname !== extname(newFilename)) {
+      const oldFilePath = `./upload/${user.id}/${user.name}${oldExtname}`;
+      if (existsSync(oldFilePath)) {
+        unlinkSync(oldFilePath);
+      }
+    }
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { FileModule } from 'src/file/file.module';
 import { AuthModule } from '../auth/auth.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [AuthModule, PrismaModule],
+  imports: [AuthModule, PrismaModule, FileModule],
   controllers: [UsersController],
   providers: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,6 +1,4 @@
-import { createReadStream, existsSync, unlinkSync } from 'fs';
-import { extname } from 'path';
-import { Injectable, StreamableFile } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { User } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateUserColumns } from './interfaces/update-user-columns.interface';
@@ -24,21 +22,5 @@ export class UsersService {
     });
 
     return updateUser;
-  }
-
-  streamAvatar(path: string): StreamableFile {
-    const file = createReadStream(path);
-
-    return new StreamableFile(file);
-  }
-
-  deleteOldFile(newFilename: string, user: User): void {
-    const oldExtname = extname(user.avatarUrl);
-    if (oldExtname !== extname(newFilename)) {
-      const oldFilePath = `./upload/${user.id}/${user.name}${oldExtname}`;
-      if (existsSync(oldFilePath)) {
-        unlinkSync(oldFilePath);
-      }
-    }
   }
 }


### PR DESCRIPTION
- file の処理を分けた方がusers がスッキリすると思って、file module 作成しました。
- controller はなく、service のみです。

(@UseInterceptors のようにメソッドの外にある場合、this 使えないため、multerOptionsなどは、static 関数で実装しました。いい方法あったら知りたい）