### PR TITLE
issueを立てたらprojectに自動生成されるように

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue
+    about: Issue template
+    url: https://github.com/ft_transcendence/issues/new?projects=yshima42/2


### PR DESCRIPTION
## 参考
[GitHub で issue を登録する時に自動でプロジェクトを指定する \- Qiita](https://qiita.com/tanabee/items/bb8817cf683fc35f0b05)