### PR TITLE
User account/develop フレンドリクエストを送るページを作成した

### DIFF
--- a/backend/src/friend-requests/friend-requests.service.spec.ts
+++ b/backend/src/friend-requests/friend-requests.service.spec.ts
@@ -451,4 +451,32 @@ describe('FriendRequestsService', () => {
       ).resolves.toStrictEqual([]);
     });
   });
+
+  describe('findRequestableUsers', () => {
+    it('should find requestable users', async () => {
+      await prisma.friendRequest.createMany({
+        data: [
+          {
+            creatorId: userArray[0].id,
+            receiverId: userArray[1].id,
+            status: 'PENDING',
+          },
+          {
+            creatorId: userArray[0].id,
+            receiverId: userArray[2].id,
+            status: 'ACCEPTED',
+          },
+          {
+            creatorId: userArray[3].id,
+            receiverId: userArray[0].id,
+            status: 'PENDING',
+          },
+        ],
+      });
+
+      await expect(
+        friendRequestsService.findRequestableUsers(userArray[0].id)
+      ).resolves.toStrictEqual([userArray[4], userArray[5]]);
+    });
+  });
 });

--- a/backend/src/friend-requests/friend-requests.service.ts
+++ b/backend/src/friend-requests/friend-requests.service.ts
@@ -88,6 +88,36 @@ export class FriendRequestsService {
     });
   }
 
+  async findRequestableUsers(id: string): Promise<User[]> {
+    return await this.prisma.user.findMany({
+      where: {
+        NOT: {
+          id,
+        },
+        AND: [
+          {
+            receiver: {
+              every: {
+                NOT: {
+                  creatorId: id,
+                },
+              },
+            },
+          },
+          {
+            creator: {
+              every: {
+                NOT: {
+                  receiverId: id,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+  }
+
   async update(
     updateFriendRequestDto: UpdateFriendRequestDto
   ): Promise<FriendRequest> {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -382,4 +382,14 @@ export class UsersController {
   async findIncomingRequest(@GetUser() user: User): Promise<User[]> {
     return await this.friendRequestService.findIncomingRequest(user.id);
   }
+
+  @Get('me/requestable-users')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: '自分がフレンドリクエストを送ることができるユーザー一覧取得',
+  })
+  @ApiOkResponse({ type: UserEntity, isArray: true })
+  async findRequetableUsers(@GetUser() user: User): Promise<User[]> {
+    return await this.friendRequestService.findRequestableUsers(user.id);
+  }
 }

--- a/frontend/src/features/friends/components/organisms/RequestableUsersList.tsx
+++ b/frontend/src/features/friends/components/organisms/RequestableUsersList.tsx
@@ -9,7 +9,7 @@ type Props = {
   users: User[];
 };
 
-export const UsersList: FC<Props> = (props) => {
+export const RequestableUsersList: FC<Props> = (props) => {
   const { users } = props;
   const [userList, setUserList] = useState<User[]>(users);
   useEffect(() => {
@@ -31,7 +31,7 @@ export const UsersList: FC<Props> = (props) => {
       }}
       gap={6}
     >
-      {users.map((user) => (
+      {userList.map((user) => (
         <UserCard
           key={user.id}
           username={user.name}

--- a/frontend/src/features/friends/hooks/useRequest.ts
+++ b/frontend/src/features/friends/hooks/useRequest.ts
@@ -3,8 +3,8 @@ import { axios } from 'lib/axios';
 
 export const useRequest = (): { request: (id: string) => void } => {
   async function request(id: string): Promise<void> {
-    await axios.post<User[]>('/friendships/request', {
-      peerId: id,
+    await axios.post<User[]>('/users/me/friend-requests', {
+      receiverId: id,
     });
   }
 

--- a/frontend/src/features/friends/routes/Users.tsx
+++ b/frontend/src/features/friends/routes/Users.tsx
@@ -9,7 +9,7 @@ import { PendingList } from 'features/friends/components/organisms/PendingList';
 import { RecognitionList } from 'features/friends/components/organisms/RecognitionList';
 import { RequestableUsersList } from 'features/friends/components/organisms/RequestableUsersList';
 
-const tabs = ['Friends', 'Pending', 'Recognition', 'Blocked', 'Users'];
+const tabs = ['Friends', 'Pending', 'Recognition', 'Blocked', 'Add Friend'];
 
 export const Users: FC = memo(() => {
   const [requestableUsers, setRequestableUsers] = useState<User[]>([]);

--- a/frontend/src/features/friends/routes/Users.tsx
+++ b/frontend/src/features/friends/routes/Users.tsx
@@ -7,12 +7,12 @@ import { BlockedList } from 'features/friends/components/organisms/BlockedList';
 import { FriendsList } from 'features/friends/components/organisms/FriendsList';
 import { PendingList } from 'features/friends/components/organisms/PendingList';
 import { RecognitionList } from 'features/friends/components/organisms/RecognitionList';
-import { UsersList } from 'features/friends/components/organisms/UsersList';
+import { RequestableUsersList } from 'features/friends/components/organisms/RequestableUsersList';
 
 const tabs = ['Friends', 'Pending', 'Recognition', 'Blocked', 'Users'];
 
 export const Users: FC = memo(() => {
-  const [users, setUsers] = useState<User[]>([]);
+  const [requestableUsers, setRequestableUsers] = useState<User[]>([]);
   const [friends, setFriends] = useState<User[]>([]);
   const [pending, setPending] = useState<User[]>([]);
   const [recognition, setRecognition] = useState<User[]>([]);
@@ -26,12 +26,14 @@ export const Users: FC = memo(() => {
   }, []);
 
   // TODO ここはSearchに置き換わる
-  async function getAllUsers(): Promise<void> {
-    const res: { data: User[] } = await axios.get('/users/all');
-    setUsers(res.data);
+  async function getRequestableUsers(): Promise<void> {
+    const res: { data: User[] } = await axios.get(
+      '/users/me/requestable-users'
+    );
+    setRequestableUsers(res.data);
   }
   useEffect(() => {
-    getAllUsers().catch((err) => console.error(err));
+    getRequestableUsers().catch((err) => console.error(err));
   }, [tabIndex]);
 
   async function getFriends(): Promise<void> {
@@ -102,7 +104,7 @@ export const Users: FC = memo(() => {
             <BlockedList users={blocked} />
           </TabPanel>
           <TabPanel>
-            <UsersList users={users} />
+            <RequestableUsersList users={requestableUsers} />
           </TabPanel>
         </TabPanels>
       </Tabs>


### PR DESCRIPTION
#108 
- Add Friendタブを作成し、リクエストを送ることができるユーザー一覧を表示させました
リクエストを送っている相手、受け取っている相手、フレンドは表示しない
- リクエストを送れるユーザーだけ表示するapiを作りました
- 全ユーザーを表示させていたUserタブを削除しました