### PR TITLE
fix: アバター変更時に一部のアイコンが再レンダリングされないバグを修正した

### DIFF
--- a/frontend/src/hooks/api/generics/usePostFileApi.ts
+++ b/frontend/src/hooks/api/generics/usePostFileApi.ts
@@ -1,4 +1,8 @@
-import { UseMutateAsyncFunction, useMutation } from '@tanstack/react-query';
+import {
+  UseMutateAsyncFunction,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { axios } from '../../../lib/axios';
 
 export interface FileReqBody {
@@ -18,7 +22,13 @@ export function usePostFileApi<ResBody>(endpoint: string): {
     return result.data;
   };
 
-  const { mutateAsync: postFunc, isLoading } = useMutation(axiosPost);
+  const queryClient = useQueryClient();
+
+  const { mutateAsync: postFunc, isLoading } = useMutation(axiosPost, {
+    onSuccess: () => {
+      void queryClient.invalidateQueries(['/users/me/profile']);
+    },
+  });
 
   return { postFunc, isLoading };
 }


### PR DESCRIPTION
ファイルをアップロードする時に、自分のプロフィールのキャッシュを無効化しました。
[Invalidation from Mutations \| TanStack Query Docs](https://tanstack.com/query/v4/docs/guides/invalidations-from-mutations)
[Query Invalidation \| TanStack Query Docs](https://tanstack.com/query/v4/docs/guides/query-invalidation)