### PR TITLE
ゲーム 別socket 対応

### DIFF
--- a/backend/src/game/game.object.ts
+++ b/backend/src/game/game.object.ts
@@ -53,20 +53,13 @@ class Paddle {
 }
 
 export class Player {
-  socket: Socket;
   id: string;
   nickname: string;
   isLeftSide: boolean;
   isReady: boolean;
   score: number;
 
-  constructor(
-    socket: Socket,
-    id: string,
-    nickname: string,
-    isLeftSide: boolean
-  ) {
-    this.socket = socket;
+  constructor(id: string, nickname: string, isLeftSide: boolean) {
     this.id = id;
     this.nickname = nickname;
     this.isLeftSide = isLeftSide;
@@ -244,10 +237,7 @@ export class GameRoom {
     }
   }
 
-  async disconnectAll(): Promise<void> {
-    await Promise.all([
-      this.player2.socket.leave(this.id),
-      this.player1.socket.leave(this.id),
-    ]);
+  disconnectAll(): void {
+    this.server.socketsLeave(this.id);
   }
 }

--- a/backend/src/game/game.object.ts
+++ b/backend/src/game/game.object.ts
@@ -80,6 +80,7 @@ export class GameRoom {
   paddle2: Paddle;
   interval: NodeJS.Timer;
   isInGame: boolean;
+  isFinished: boolean;
 
   constructor(
     gameService: GameService,
@@ -100,6 +101,7 @@ export class GameRoom {
       // イニシャライズのための空変数
     });
     this.isInGame = false;
+    this.isFinished = false;
   }
 
   setBallCenter(): void {
@@ -167,6 +169,7 @@ export class GameRoom {
   }
 
   async doneGame(roomId: string): Promise<void> {
+    this.isFinished = true;
     // setIntervalを止める処理
     clearInterval(this.interval);
 
@@ -235,9 +238,5 @@ export class GameRoom {
         this.paddle2.y = 0;
       }
     }
-  }
-
-  disconnectAll(): void {
-    this.server.socketsLeave(this.id);
   }
 }

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -261,12 +261,12 @@ export class UsersGateway {
     message: {
       roomId: string;
       userCommand: { up: boolean; down: boolean; isLeftSide: boolean };
-    }
-    // @ConnectedSocket() socket: Socket
+    },
+    @ConnectedSocket() socket: Socket
   ): void {
     const gameRoom = this.gameRooms.get(message.roomId);
     if (gameRoom === undefined) {
-      // socket.emit('invalid_room');
+      socket.emit('invalid_room');
 
       return;
     }

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -69,7 +69,7 @@ export class UsersGateway {
 
     // disconnect されたら、room からも自動で消えるため、一旦コメントアウト
     // await socket.leave(userId);
-    // await socket.leave(`matching`);
+    // await socket.leave('matching');
     await this.leaveGameRoom(socket);
 
     // debug用
@@ -129,12 +129,12 @@ export class UsersGateway {
     const { userId: waitUserId, userNickname: waitUserNickname } =
       matchingSockets[0].data as { userId: string; userNickname: string };
     if (waitUserId === userId) {
-      await socket.join(`matching`);
+      await socket.join('matching');
 
       return;
     }
 
-    this.server.socketsLeave(`matching`);
+    this.server.socketsLeave('matching');
     const player1 = new Player(waitUserId, waitUserNickname, true);
     const player2 = new Player(userId, userNickname, false);
     // 2人揃ったらマッチルーム作る
@@ -163,7 +163,7 @@ export class UsersGateway {
       `${socket.id} ${socket.data.userNickname as string} matching_cancel`
     );
 
-    await socket.leave(`matching`);
+    await socket.leave('matching');
   }
 
   // room関連;

--- a/frontend/src/features/game/hooks/useGame.ts
+++ b/frontend/src/features/game/hooks/useGame.ts
@@ -143,6 +143,7 @@ export const useGame = (
     });
 
     return () => {
+      socket.emit('leave_room');
       socket.off('invalid_room');
       socket.off('set_side');
       socket.off('check_confirmation');
@@ -174,7 +175,7 @@ export const useGame = (
       }
       case GamePhase.Confirming: {
         console.log('[GamePhase] Confirming');
-        socket.emit('confirm', { roomId });
+        socket.emit('confirm');
         break;
       }
       case GamePhase.OpponentWaiting: {
@@ -183,13 +184,12 @@ export const useGame = (
       }
       case GamePhase.InGame: {
         console.log('[GamePhase] InGame');
-        socket.emit('connect_pong', { roomId });
+        socket.emit('connect_pong');
         userInput(socket, roomId, isLeftSide);
         break;
       }
       case GamePhase.Result: {
         console.log('[GamePhase] Result');
-        socket.emit('delete_room', { roomId });
         break;
       }
     }

--- a/frontend/src/features/game/hooks/useGame.ts
+++ b/frontend/src/features/game/hooks/useGame.ts
@@ -174,7 +174,7 @@ export const useGame = (
       }
       case GamePhase.Confirming: {
         console.log('[GamePhase] Confirming');
-        socket.emit('confirm', { roomId, isLeftSide });
+        socket.emit('confirm', { roomId });
         break;
       }
       case GamePhase.OpponentWaiting: {

--- a/frontend/src/features/game/utils/userInput.ts
+++ b/frontend/src/features/game/utils/userInput.ts
@@ -29,7 +29,7 @@ export const userInput = (
       }
       if (justPressed) {
         if (socket != null) {
-          socket.emit('user_command', { roomId, userCommand });
+          socket.emit('user_command', { userCommand });
           justPressed = false;
         }
       }
@@ -47,7 +47,7 @@ export const userInput = (
       }
       if (justPressed) {
         if (socket != null) {
-          socket.emit('user_command', { roomId, userCommand });
+          socket.emit('user_command', { userCommand });
         }
       }
     },


### PR DESCRIPTION
やったこと
- ユーザー用のソケットルームを作成した。そのroom に送信すれば、別タブでも同期が取れる。
- /app/matching ページを別タブ対応。
  - マッチングかける とマッチングキャンセルは同期をとらない、マッチング成功は同期をとる。
  - matchWaitingPlayers 削除して、matching ソケットルーム を使うようにした。
- /app/games/:id ページを別タブ対応。
  - 同期をとる、裏で動く、再接続できる。
- gameRoom の削除を、playerどちらもがゲーム画面から離れた場合に行うようにした。
  これに伴い、roomId をsocket.data.roomId に入れて、handleDisconnect でroom を特定できるようにした。
- ゲーム中に別タブでマッチングかけれるのは、まだ未対応で、未定義動作です。