### PR TITLE
ワンタイムパスワード認証時のトークンを、PostAPIのボディで渡すようにしました。

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,6 +9,7 @@ import {
   Redirect,
   Query,
   Delete,
+  Body,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from '@prisma/client';
@@ -195,21 +196,20 @@ export class AuthController {
    * @param res - cookie用
    * @returns リダイレクト先
    */
-  @Get('otp/validation')
+  @Post('otp/validation')
   @HttpCode(200)
-  @Redirect('http://localhost:5173/app')
   @UseGuards(JwtAuthGuard)
   async validateOtp(
     @GetUser() user: User,
-    @Query('one-time-password') oneTimePassword: string,
+    @Body('oneTimePassword') oneTimePassword: string,
     @Res({ passthrough: true }) res: Response
-  ): Promise<{ url: string }> {
+  ): Promise<{ isCodeValid: boolean }> {
     const isCodeValid = await this.authService.validateOtp(
       oneTimePassword,
       user
     );
     if (!isCodeValid) {
-      return { url: 'http://localhost:5173/' };
+      return { isCodeValid };
     }
 
     const { accessToken } = await this.authService.generateJwt(
@@ -220,6 +220,34 @@ export class AuthController {
 
     res.cookie('accessToken', accessToken, this.cookieOptions);
 
-    return { url: 'http://localhost:5173/app' };
+    return { isCodeValid };
   }
+
+  // @Get('otp/validation')
+  // @HttpCode(200)
+  // @Redirect('http://localhost:5173/app')
+  // @UseGuards(JwtAuthGuard)
+  // async validateOtp(
+  //   @GetUser() user: User,
+  //   @Query('one-time-password') oneTimePassword: string,
+  //   @Res({ passthrough: true }) res: Response
+  // ): Promise<{ url: string }> {
+  //   const isCodeValid = await this.authService.validateOtp(
+  //     oneTimePassword,
+  //     user
+  //   );
+  //   if (!isCodeValid) {
+  //     return { url: 'http://localhost:5173/' };
+  //   }
+
+  //   const { accessToken } = await this.authService.generateJwt(
+  //     user.id,
+  //     user.name,
+  //     true
+  //   );
+
+  //   res.cookie('accessToken', accessToken, this.cookieOptions);
+
+  //   return { url: 'http://localhost:5173/app' };
+  // }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -189,12 +189,12 @@ export class AuthController {
   /**
    * 入力されたワンタイムパスワードの検証。
    * 正しければ、valid=trueを付与したaccessTokenを
-   * cookieに割り当てて、アプリトップへリダイレクト。
-   * 間違っていれば、ログインページにリダイレクト。
+   * cookieに割り当てて、true返却。
+   * 間違っていれば、何もしないでfalse返却。
    * @param user
-   * @param oneTimePassword - クエリから取得。
+   * @param oneTimePassword - Bodyから取得。
    * @param res - cookie用
-   * @returns リダイレクト先
+   * @returns bool値
    */
   @Post('otp/validation')
   @HttpCode(200)
@@ -208,46 +208,16 @@ export class AuthController {
       oneTimePassword,
       user
     );
-    if (!isCodeValid) {
-      return { isCodeValid };
+    if (isCodeValid) {
+      const { accessToken } = await this.authService.generateJwt(
+        user.id,
+        user.name,
+        true
+      );
+
+      res.cookie('accessToken', accessToken, this.cookieOptions);
     }
-
-    const { accessToken } = await this.authService.generateJwt(
-      user.id,
-      user.name,
-      true
-    );
-
-    res.cookie('accessToken', accessToken, this.cookieOptions);
 
     return { isCodeValid };
   }
-
-  // @Get('otp/validation')
-  // @HttpCode(200)
-  // @Redirect('http://localhost:5173/app')
-  // @UseGuards(JwtAuthGuard)
-  // async validateOtp(
-  //   @GetUser() user: User,
-  //   @Query('one-time-password') oneTimePassword: string,
-  //   @Res({ passthrough: true }) res: Response
-  // ): Promise<{ url: string }> {
-  //   const isCodeValid = await this.authService.validateOtp(
-  //     oneTimePassword,
-  //     user
-  //   );
-  //   if (!isCodeValid) {
-  //     return { url: 'http://localhost:5173/' };
-  //   }
-
-  //   const { accessToken } = await this.authService.generateJwt(
-  //     user.id,
-  //     user.name,
-  //     true
-  //   );
-
-  //   res.cookie('accessToken', accessToken, this.cookieOptions);
-
-  //   return { url: 'http://localhost:5173/app' };
-  // }
 }

--- a/frontend/src/features/auth/routes/OtpAuth.tsx
+++ b/frontend/src/features/auth/routes/OtpAuth.tsx
@@ -8,7 +8,7 @@ import {
   HStack,
   Input,
 } from '@chakra-ui/react';
-import { useOtpAuthValidate } from 'hooks/api/auth/useOtpAuthValidate';
+import { useOtpAuthValidate } from 'hooks/api';
 import { useNavigate } from 'react-router-dom';
 
 export const OtpAuth: FC = memo(() => {

--- a/frontend/src/features/auth/routes/OtpAuth.tsx
+++ b/frontend/src/features/auth/routes/OtpAuth.tsx
@@ -8,12 +8,21 @@ import {
   HStack,
   Input,
 } from '@chakra-ui/react';
+import { useOtpAuthValidate } from 'hooks/api/auth/useOtpAuthValidate';
+import { useNavigate } from 'react-router-dom';
 
 export const OtpAuth: FC = memo(() => {
+  const navigate = useNavigate();
   const [token, setToken] = useState('');
+  const { validateOtpAuth, isLoading } = useOtpAuthValidate();
 
   const onChangeToken = (e: ChangeEvent<HTMLInputElement>) => {
     setToken(e.target.value);
+  };
+
+  const onClickSubmit = async () => {
+    const { isCodeValid } = await validateOtpAuth({ oneTimePassword: token });
+    navigate(isCodeValid ? '/app' : '/');
   };
 
   return (
@@ -33,8 +42,9 @@ export const OtpAuth: FC = memo(() => {
           <Button
             bg="teal.300"
             color="white"
-            as="a"
-            href={`http://localhost:3000/auth/otp/validation?one-time-password=${token}`}
+            onClick={onClickSubmit}
+            isLoading={isLoading}
+            isDisabled={isLoading}
           >
             submit
           </Button>

--- a/frontend/src/hooks/api/auth/useOtpAuthValidate.ts
+++ b/frontend/src/hooks/api/auth/useOtpAuthValidate.ts
@@ -1,0 +1,33 @@
+import { UseMutateAsyncFunction } from '@tanstack/react-query';
+import { usePostApi } from '../generics/usePostApi';
+
+export interface ValidateOtpAuthReqBody {
+  oneTimePassword: string;
+}
+
+export interface ValidateOtpAuthResBody {
+  isCodeValid: boolean;
+}
+
+export type ValidateOtpAuth = UseMutateAsyncFunction<
+  ValidateOtpAuthResBody,
+  unknown,
+  ValidateOtpAuthReqBody,
+  unknown
+>;
+
+export const useOtpAuthValidate = (): {
+  validateOtpAuth: ValidateOtpAuth;
+  isLoading: boolean;
+  isSuccess: boolean;
+} => {
+  const {
+    postFunc: validateOtpAuth,
+    isLoading,
+    isSuccess,
+  } = usePostApi<ValidateOtpAuthReqBody, ValidateOtpAuthResBody>(
+    '/auth/otp/validation'
+  );
+
+  return { validateOtpAuth, isLoading, isSuccess };
+};

--- a/frontend/src/hooks/api/index.ts
+++ b/frontend/src/hooks/api/index.ts
@@ -4,6 +4,7 @@ export * from './auth/useIsOtpAuthEnabled';
 export * from './auth/useLogout';
 export * from './auth/useOtpAuthCreate';
 export * from './auth/useOtpAuthDelete';
+export * from './auth/useOtpAuthValidate';
 export * from './auth/useOtpQrcodeUrl';
 
 // block


### PR DESCRIPTION
ログインするときに、ワンタイムパスワードをクエリでサーバーに渡していましたが、　セキュリティ上あまり良くないので、GETからPOSTメソッドに変更し、ボディとして渡すように変更しました。