### PR TITLE
Game/dev/bag fix

### DIFF
--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -159,6 +159,7 @@ export class UsersGateway {
     const player1 = new Player(userId, true);
     const player2 = new Player(message.opponentId, false);
     const gameRoom = this.createGameRoom(player1, player2, message.ballSpeed);
+    socket.data.roomId = gameRoom.id;
     this.server.to(player2.id).emit('receive_invitation', {
       roomId: gameRoom.id,
       challengerId: player1.id,
@@ -193,7 +194,15 @@ export class UsersGateway {
     if (gameRoom !== undefined) {
       this.server.to(gameRoom.player1.id).emit('player2_decline_invitation');
     }
-    socket.data.roomId = message.roomId;
+    await this.leaveGameRoom(socket);
+  }
+
+  @SubscribeMessage('cancel_invitation')
+  async cancel_invitation(@ConnectedSocket() socket: Socket): Promise<void> {
+    Logger.debug(
+      `${socket.id} ${socket.data.userId as string} cancel_invitation`
+    );
+
     await this.leaveGameRoom(socket);
   }
 

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -159,7 +159,7 @@ export class UsersGateway {
     const player1 = new Player(userId, true);
     const player2 = new Player(message.opponentId, false);
     const gameRoom = this.createGameRoom(player1, player2, message.ballSpeed);
-    socket.data.roomId = gameRoom.id;
+    socket.data.gameRoomId = gameRoom.id;
     this.server.to(player2.id).emit('receive_invitation', {
       roomId: gameRoom.id,
       challengerId: player1.id,
@@ -194,6 +194,7 @@ export class UsersGateway {
     if (gameRoom !== undefined) {
       this.server.to(gameRoom.player1.id).emit('player2_decline_invitation');
     }
+    socket.data.roomId = message.roomId;
     await this.leaveGameRoom(socket);
   }
 

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -193,6 +193,7 @@ export class UsersGateway {
     if (gameRoom !== undefined) {
       this.server.to(gameRoom.player1.id).emit('player2_decline_invitation');
     }
+    socket.data.roomId = message.roomId;
     await this.leaveGameRoom(socket);
   }
 

--- a/frontend/src/features/game/hooks/useGameInviting.ts
+++ b/frontend/src/features/game/hooks/useGameInviting.ts
@@ -68,6 +68,7 @@ export const useGameInvitation = (): {
         break;
       }
       case InviteState.InvitingCancel: {
+        socket.emit('cancel_invitation');
         customToast({
           title: 'Declined',
           description: 'Your Invitation was declined',

--- a/frontend/src/features/game/hooks/useGameInviting.ts
+++ b/frontend/src/features/game/hooks/useGameInviting.ts
@@ -42,9 +42,6 @@ export const useGameInvitation = (): {
     });
 
     return () => {
-      if (inviteState === InviteState.Inviting) {
-        socket.emit('inviting_cancel');
-      }
       socket.off('go_game_room_by_invitation');
     };
   }, [socket, inviteState, navigate]);


### PR DESCRIPTION
## やったこと
- プロフィールページからオンラインのユーザーに対してゲーム対戦申し込みをした時、①招待者がCancelを押す、②招待された人がDeclineを押す、両ケースでIn-Game Listから対戦が消える(以前は表示したままになっていた)

## やってないこと
- 招待した後、招待者がcancelを押した時に招待された人にInvitationのポップが表示され続ける部分の修正(修正しなくてもacceptしたらinvalid gameRoom idのトーストが表示される)