### PR TITLE
Game/dev/invitation fix

### DIFF
--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -161,6 +161,7 @@ export class UsersGateway {
     // const gameRoom = this.createGameRoom(player1, player2, message.ballSpeed);
     this.server.to(message.opponentId).emit('receive_invitation', {
       challengerId: userId,
+      ballSpeed: message.ballSpeed,
     });
   }
 

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -156,9 +156,6 @@ export class UsersGateway {
     );
 
     const { userId } = socket.data as { userId: string };
-    // const player1 = new Player(userId, true);
-    // const player2 = new Player(message.opponentId, false);
-    // const gameRoom = this.createGameRoom(player1, player2, message.ballSpeed);
     this.server.to(message.opponentId).emit('receive_invitation', {
       challengerId: userId,
       ballSpeed: message.ballSpeed,
@@ -200,6 +197,18 @@ export class UsersGateway {
     this.server.to(message.challengerId).emit('player2_decline_invitation');
 
     await this.leaveGameRoom(socket);
+  }
+
+  @SubscribeMessage('cancel_invitation')
+  cancel_invitation(
+    @ConnectedSocket() socket: Socket,
+    @MessageBody() message: { opponentId: string }
+  ): void {
+    Logger.debug(
+      `${socket.id} ${socket.data.userId as string} cancel_invitation`
+    );
+
+    this.server.to(message.opponentId).emit('player1_cancel_invitation');
   }
 
   @SubscribeMessage('join_game_room')

--- a/frontend/src/features/game/hooks/useGameInviting.ts
+++ b/frontend/src/features/game/hooks/useGameInviting.ts
@@ -42,9 +42,6 @@ export const useGameInvitation = (): {
     });
 
     return () => {
-      if (inviteState === InviteState.Inviting) {
-        socket.emit('inviting_cancel');
-      }
       socket.off('go_game_room_by_invitation');
     };
   }, [socket, inviteState, navigate]);

--- a/frontend/src/features/game/hooks/useGameInviting.ts
+++ b/frontend/src/features/game/hooks/useGameInviting.ts
@@ -44,6 +44,7 @@ export const useGameInvitation = (): {
 
     return () => {
       socket.off('go_game_room_by_invitation');
+      socket.off('player2_decline_invitation');
     };
   }, [socket, inviteState, navigate]);
 

--- a/frontend/src/features/game/hooks/useGameInviting.ts
+++ b/frontend/src/features/game/hooks/useGameInviting.ts
@@ -8,7 +8,8 @@ export enum InviteState {
   GamePreference = 1,
   Inviting = 2,
   InvitingCancel = 3,
-  Matched = 4,
+  InvitingDeclined = 4,
+  Matched = 5,
 }
 
 export const useGameInvitation = (): {
@@ -38,7 +39,7 @@ export const useGameInvitation = (): {
 
     socket.on('player2_decline_invitation', () => {
       console.log('[Socket Event] go_game_room_by_invitation');
-      setInviteState(InviteState.InvitingCancel);
+      setInviteState(InviteState.InvitingDeclined);
     });
 
     return () => {
@@ -65,12 +66,21 @@ export const useGameInvitation = (): {
         break;
       }
       case InviteState.InvitingCancel: {
+        if (opponentId !== undefined) {
+          socket.emit('cancel_invitation', {
+            opponentId,
+          });
+        }
+        navigate(-1);
+        break;
+      }
+      case InviteState.InvitingDeclined: {
         customToast({
           title: 'Declined',
           description: 'Your Invitation was declined',
           status: 'warning',
         });
-        navigate('/app');
+        navigate(-1);
         break;
       }
     }

--- a/frontend/src/providers/SocketProvider.tsx
+++ b/frontend/src/providers/SocketProvider.tsx
@@ -100,6 +100,10 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
       }
     );
 
+    socket.on('player1_cancel_invitation', () => {
+      onClose();
+    });
+
     return () => {
       socket.off('connect_established');
       socket.off('set_presence');
@@ -107,6 +111,7 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
       socket.off('set_game_room_id');
       socket.off('delete_game_room_id');
       socket.off('receive_invitation');
+      socket.off('player1_cancel_invitation');
     };
   }, [socket]);
 

--- a/frontend/src/providers/SocketProvider.tsx
+++ b/frontend/src/providers/SocketProvider.tsx
@@ -91,14 +91,10 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
       setUserIdToGameRoomIdMap(new Map<string, string>(userIdToGameRoomIdMap));
     });
 
-    socket.on(
-      'receive_invitation',
-      (message: { roomId: string; challengerId: string }) => {
-        setChallengerId(message.challengerId);
-        onOpen();
-        setInvitationGameRoomId(message.roomId);
-      }
-    );
+    socket.on('receive_invitation', (message: { challengerId: string }) => {
+      setChallengerId(message.challengerId);
+      onOpen();
+    });
 
     return () => {
       socket.off('connect_established');
@@ -117,13 +113,19 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const onClickAccept = () => {
     onClose();
-    socket.emit('accept_invitation', { roomId: invitationGameRoomId });
-    navigate(`/app/games/${invitationGameRoomId}`);
+    socket.emit(
+      'accept_invitation',
+      { challengerId },
+      (message: { roomId: string }) => {
+        setInvitationGameRoomId(message.roomId);
+        navigate(`/app/games/${invitationGameRoomId}`);
+      }
+    );
   };
 
   const onClickDecline = () => {
     onClose();
-    socket.emit('decline_invitation', { roomId: invitationGameRoomId });
+    socket.emit('decline_invitation', { challengerId });
   };
 
   return (

--- a/frontend/src/providers/SocketProvider.tsx
+++ b/frontend/src/providers/SocketProvider.tsx
@@ -40,8 +40,8 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
   const [isConnected, setConnected] = useState(false);
   const didLogRef = useRef(false);
   const navigate = useNavigate();
-  const [invitationGameRoomId, setInvitationGameRoomId] = useState('');
   const [challengerId, setChallengerId] = useState('');
+  const [ballSpeed, setBallSpeed] = useState(0);
 
   useEffect(() => {
     socket.on('connect_established', () => {
@@ -91,10 +91,14 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
       setUserIdToGameRoomIdMap(new Map<string, string>(userIdToGameRoomIdMap));
     });
 
-    socket.on('receive_invitation', (message: { challengerId: string }) => {
-      setChallengerId(message.challengerId);
-      onOpen();
-    });
+    socket.on(
+      'receive_invitation',
+      (message: { challengerId: string; ballSpeed: number }) => {
+        setChallengerId(message.challengerId);
+        setBallSpeed(message.ballSpeed);
+        onOpen();
+      }
+    );
 
     return () => {
       socket.off('connect_established');
@@ -115,10 +119,9 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
     onClose();
     socket.emit(
       'accept_invitation',
-      { challengerId },
+      { challengerId, ballSpeed },
       (message: { roomId: string }) => {
-        setInvitationGameRoomId(message.roomId);
-        navigate(`/app/games/${invitationGameRoomId}`);
+        navigate(`/app/games/${message.roomId}`);
       }
     );
   };


### PR DESCRIPTION
## 概要
- Invitationの設計をrandomマッチの設計と同様の設計にしました。以前はgameRoomをinvitationの時点で作っていたので、acceptしたタイミングで作るようにすることで以下3つ出てたbagを修正しました。
- https://github.com/yshima42/ft_transcendence/issues/299
- https://github.com/yshima42/ft_transcendence/issues/256
- https://github.com/yshima42/ft_transcendence/issues/254

## やったこと(確認方法)
- プロフィールページからオンラインのユーザーに対してゲーム対戦申し込みをした時には、アクセプトするまでIn-Game Listに表示されないようにした(以前は招待した瞬間にIn-Game Listに表示されていた)
- 招待した後、招待者がcancelを押した時に招待された人のInvitationのポップを取り下げる挙動実装

## やってないこと
- [ ] http://localhost:5173/app/inviting に直接アクセスした時のエラー処理(https://github.com/yshima42/ft_transcendence/issues/263 )
- [ ] 招待中に、ページ遷移した時、招待された側のモーダルが出たまま。(Cancel した時と同じにするべき)
- [ ] Now Matching中、招待きたらどうするか。
- [ ] 招待されてすぐにアクセプトをするとゲームがうまく始まらないことがある(現在理由不明、gameRoomIdの設定タイミングが悪い？)
- リロード
    - [ ] 招待された側が、モーダルでてるときに、リロードすると、モーダルが消えて、Decline もされない。
       (招待中に招待された側がリロードした時の招待側への通知(必要ないと思ってます))
    - [ ] 招待してる側が、Now Inviting... 中に、リロードすると、Game Preference の表示に戻る。
- 複数タブ
    - [ ] 招待された側が、複数タブで開いているときに、片方がDeclined, Accept すると、もう片方がモーダル出たまま。
    - [ ] 招待してる側が、複数タブで招待する場合、Now Inviting...とGame Preference で、表示が違う。これの影響で不具合でそう。

### 非機能要件

- [ ] 〇〇の設定(ボールスピードはfastの5点マッチ)で招待されました的なinvitationメッセージ(非機能要件)
