### PR TITLE
user-presence のbug-fix

### DIFF
--- a/frontend/src/features/game/hooks/useGameMonitoring.ts
+++ b/frontend/src/features/game/hooks/useGameMonitoring.ts
@@ -23,28 +23,37 @@ export const useGameMonitoring = (): {
     if (!isConnected) return;
 
     socket.emit('join_monitor_room', (inGameOutlines: GameOutline[]) => {
-      inGameOutlines.forEach((inGameOutline) =>
-        inGameOutlineMap.set(inGameOutline.roomId, {
-          roomId: inGameOutline.roomId,
-          player1Id: inGameOutline.player1Id,
-          player2Id: inGameOutline.player2Id,
-        })
-      );
-      setInGameOutlineMap(new Map<string, GameOutline>(inGameOutlineMap));
+      setInGameOutlineMap((inGameOutlineMap) => {
+        inGameOutlines.forEach((inGameOutline) =>
+          inGameOutlineMap.set(inGameOutline.roomId, {
+            roomId: inGameOutline.roomId,
+            player1Id: inGameOutline.player1Id,
+            player2Id: inGameOutline.player2Id,
+          })
+        );
+
+        return new Map<string, GameOutline>(inGameOutlineMap);
+      });
     });
 
     socket.on('game_room_created', (createdRoomOutline: GameOutline) => {
-      inGameOutlineMap.set(createdRoomOutline.roomId, {
-        roomId: createdRoomOutline.roomId,
-        player1Id: createdRoomOutline.player1Id,
-        player2Id: createdRoomOutline.player2Id,
+      setInGameOutlineMap((inGameOutlineMap) => {
+        inGameOutlineMap.set(createdRoomOutline.roomId, {
+          roomId: createdRoomOutline.roomId,
+          player1Id: createdRoomOutline.player1Id,
+          player2Id: createdRoomOutline.player2Id,
+        });
+
+        return new Map<string, GameOutline>(inGameOutlineMap);
       });
-      setInGameOutlineMap(new Map<string, GameOutline>(inGameOutlineMap));
     });
 
     socket.on('game_room_deleted', (deletedRoomId: string) => {
-      inGameOutlineMap.delete(deletedRoomId);
-      setInGameOutlineMap(new Map<string, GameOutline>(inGameOutlineMap));
+      setInGameOutlineMap((inGameOutlineMap) => {
+        inGameOutlineMap.delete(deletedRoomId);
+
+        return new Map<string, GameOutline>(inGameOutlineMap);
+      });
     });
 
     return () => {

--- a/frontend/src/providers/SocketProvider.tsx
+++ b/frontend/src/providers/SocketProvider.tsx
@@ -74,23 +74,35 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
     });
 
     socket.on('set_presence', (userIdToPresence: [string, Presence]) => {
-      userIdToPresenceMap.set(...userIdToPresence);
-      setUserIdToPresenceMap(new Map<string, Presence>(userIdToPresenceMap));
+      setUserIdToPresenceMap((userIdToPresenceMap) => {
+        userIdToPresenceMap.set(...userIdToPresence);
+
+        return new Map<string, Presence>(userIdToPresenceMap);
+      });
     });
 
     socket.on('delete_presence', (userId: string) => {
-      userIdToPresenceMap.delete(userId);
-      setUserIdToPresenceMap(new Map<string, Presence>(userIdToPresenceMap));
+      setUserIdToPresenceMap((userIdToPresenceMap) => {
+        userIdToPresenceMap.delete(userId);
+
+        return new Map<string, Presence>(userIdToPresenceMap);
+      });
     });
 
     socket.on('set_game_room_id', (userIdToGameRoomId: [string, string]) => {
-      userIdToGameRoomIdMap.set(...userIdToGameRoomId);
-      setUserIdToGameRoomIdMap(new Map<string, string>(userIdToGameRoomIdMap));
+      setUserIdToGameRoomIdMap((userIdToGameRoomIdMap) => {
+        userIdToGameRoomIdMap.set(...userIdToGameRoomId);
+
+        return new Map<string, string>(userIdToGameRoomIdMap);
+      });
     });
 
     socket.on('delete_game_room_id', (userId: string) => {
-      userIdToGameRoomIdMap.delete(userId);
-      setUserIdToGameRoomIdMap(new Map<string, string>(userIdToGameRoomIdMap));
+      setUserIdToGameRoomIdMap((userIdToGameRoomIdMap) => {
+        userIdToGameRoomIdMap.delete(userId);
+
+        return new Map<string, string>(userIdToGameRoomIdMap);
+      });
     });
 
     return () => {
@@ -101,7 +113,7 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
       socket.off('set_game_room_id');
       socket.off('delete_game_room_id');
     };
-  }, [socket]);
+  }, [socket, customToast]);
 
   return (
     <SocketContext.Provider

--- a/frontend/src/providers/SocketProvider.tsx
+++ b/frontend/src/providers/SocketProvider.tsx
@@ -54,12 +54,20 @@ const SocketProvider: FC<PropsWithChildren> = ({ children }) => {
             userIdToPresence: Array<[string, Presence]>;
             userIdToGameRoomId: Array<[string, string]>;
           }) => {
-            setUserIdToPresenceMap(
-              new Map<string, Presence>(message.userIdToPresence)
-            );
-            setUserIdToGameRoomIdMap(
-              new Map<string, string>(message.userIdToGameRoomId)
-            );
+            setUserIdToPresenceMap((userIdToPresenceMap) => {
+              message.userIdToPresence.forEach((userIdToPresence) => {
+                userIdToPresenceMap.set(...userIdToPresence);
+              });
+
+              return new Map<string, Presence>(userIdToPresenceMap);
+            });
+            setUserIdToGameRoomIdMap((userIdToGameRoomIdMap) => {
+              message.userIdToGameRoomId.forEach((userIdToGameRoomId) => {
+                userIdToGameRoomIdMap.set(...userIdToGameRoomId);
+              });
+
+              return new Map<string, string>(userIdToGameRoomIdMap);
+            });
           }
         );
       }


### PR DESCRIPTION
１人がdisconnect すると、他のユーザー全員がオフラインになるバグを修正

原因は、userIdToPresenceMap が依存配列に入っておらず、古いものを見ている時があったためでした。
set関数の、callback 関数の引数で最新のuserIdToPresenceMapを受け取るようにしました。

inGameRoomMap も同じように修正。