### PR TITLE
fork 先からのプルリクでもラベル付与でactions が正常実行されるように修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 
 name: build
 
-on: [pull_request]
+on:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   build:
@@ -19,6 +21,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v3
       - name: create .env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,15 @@
 name: build
 
 on:
+  pull_request:
   pull_request_target:
     types: [labeled]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ( github.event_name == 'pull_request' ) ||
+        ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     steps:
       - uses: actions/checkout@v3
       - name: backend install
@@ -21,7 +24,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
+    if: ( github.event_name == 'pull_request' ) ||
+        ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     steps:
       - uses: actions/checkout@v3
       - name: create .env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: ( github.event.pull_request.head.repo.fork == false ) ||
-        ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
+        ( contains(github.event.pull_request.labels.*.name, 'safe-to-test') )
     steps:
       - uses: actions/checkout@v3
       - name: backend install
@@ -25,7 +25,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     if: ( github.event.pull_request.head.repo.fork == false ) ||
-        ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
+        ( contains(github.event.pull_request.labels.*.name, 'safe-to-test') )
     steps:
       - uses: actions/checkout@v3
       - name: create .env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ( github.event_name == 'pull_request' ) ||
+    if: ( github.event.pull_request.head.repo.fork == false ) ||
         ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    if: ( github.event_name == 'pull_request' ) ||
+    if: ( github.event.pull_request.head.repo.fork == false ) ||
         ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# やったこと

fork 先 -> fork 元のプルリクでは、actions のpull_request イベントで、secrets を参照できない。
理由は、secrets の内容を、どこかに送信する処理を仕込まれたら、やばいから。
pull_request_target イベントであれば、secrets を参照できるが、安全にする処理が必要。
公式ブログを参考に、`safe-to-test`というラベルがつけられたらactions 実行するようにした。

[fork されたリポジトリからのプルリクで Actions のシークレットを参照できるようにしたい](https://zenn.dev/odan/scraps/cce2165dc91080)
[欅樹雑記: GitHub Actionsでシークレットを扱うときの注意](https://blog.zelkova.cc/2020/05/attentions-of-using-secrets-on-github-actions.html)
[GitHub Actionの\`on: pull\_request\`と\`on: pull\_request\_target\`の違いMEMO \- Madogiwa Blog](https://madogiwa0124.hatenablog.com/entry/2022/05/29/110148)

# 確認方法

このプルリク(自身)では、actions のtest.yml は実行されている！
デプロイのプルリク(fork先->fork元) のtest.ymlにも、同じ処理を書いたのですが、test.yml は実行されていない！
`safe-to-test`というラベルをつけると、実行されるはず。-> mainにこのtest.ymlが入らないと起動しないかも？